### PR TITLE
adding support for several arguments in Panicf

### DIFF
--- a/ULog.go
+++ b/ULog.go
@@ -98,9 +98,9 @@ func Panic(v interface{}) {
 	panic(v)
 }
 
-func Panicf(fmtString string, v interface{}) {
+func Panicf(fmtString string, v ...interface{}) {
 	if globalLogLevel <= LEVEL_ERROR {
-		printOut(&fmtString, _LEVEL_ERROR, v)
+		printOut(&fmtString, _LEVEL_ERROR, v...)
 	}
 	panic(v)
 }

--- a/ULogger_test.go
+++ b/ULogger_test.go
@@ -94,11 +94,11 @@ func TestLoggingPanicf(t *testing.T) {
 		if r := recover(); r == nil {
 			t.Errorf("The code did not panic")
 		} else {
-			checkDisregardPackage(buffer, _LEVEL_ERROR, "testError test", t)
+			checkDisregardPackage(buffer, _LEVEL_ERROR, "testError test1 test2", t)
 		}
 	}()
 
-	Panicf("testError %s", "test")
+	Panicf("testError %s %s", "test1", "test2")
 }
 
 func TestLoggingFatal(t *testing.T) {


### PR DESCRIPTION
ulog.Panicf("%s %s", arg1, arg2) was not possible.

Only ulog.Panicf("%s", arg1) ...

Now it is more consistent to others like ulog,Errorf etc.
