### PR TITLE
Add option for newline replacement

### DIFF
--- a/v2/custom_encoder.go
+++ b/v2/custom_encoder.go
@@ -102,7 +102,12 @@ func (c customEncoder) EncodeEntry(ent zapcore.Entry, fields []zapcore.Field) (*
 	}
 	appendCaller(ent.Caller, line)
 	line.AppendString(c.separator)
-	line.AppendString(ent.Message)
+
+	if selectedOptions.replaceNewlines {
+		line.AppendString(strings.ReplaceAll(ent.Message, "\n", selectedOptions.newlineReplacement))
+	} else {
+		line.AppendString(ent.Message)
+	}
 
 	if !selectedOptions.stripAdditionalFields {
 		line.AppendString(c.separator)

--- a/v2/options.go
+++ b/v2/options.go
@@ -17,6 +17,8 @@ type options struct {
 	isDevelopment         bool
 	stripAdditionalFields bool
 	renderDummyThread     bool
+	replaceNewlines       bool
+	newlineReplacement    string
 	redirectOutput        io.Writer
 	additionalCores       []zapcore.Core
 }
@@ -66,6 +68,13 @@ func WithStripAdditionalFields(stripAdditionalFields bool) Option {
 func WithRenderDummyThread(renderDummyThread bool) Option {
 	return newFuncOption(func(o *options) {
 		o.renderDummyThread = renderDummyThread
+	})
+}
+
+func WithNewlineReplacement(newlineReplacement string) Option {
+	return newFuncOption(func(o *options) {
+		o.replaceNewlines = true
+		o.newlineReplacement = newlineReplacement
 	})
 }
 


### PR DESCRIPTION
Here's the PR promised on Friday.

I first went with a single `*string` field and used `nil` as the "not configured" state, but dereferencing the pointer had a big performance impact (~12k op/s with pointer vs. ~16k op/s without).